### PR TITLE
00 11 docker fixes

### DIFF
--- a/docker/httpd/httpdEntrypoint.sh
+++ b/docker/httpd/httpdEntrypoint.sh
@@ -5,11 +5,12 @@ set -e
 # certbot --apache -d dune-wfs-test.cern.ch
 
 which httpd
-
+httpd -M
+mod_wsgi-express module-config
 pwd
 
 whoami
-
+echo "Starting apache ..."
 httpd -D FOREGROUND
 
 # certbot --apache -d wfs-pro.dune.hep.ac.uk -d wfs.dune.hep.ac.uk

--- a/docker/justin/Dockerfile
+++ b/docker/justin/Dockerfile
@@ -22,6 +22,7 @@ RUN python3 -m pip install mysqlclient
 RUN python3 -m pip install wheel
 RUN python3 -m pip install setuptools_rust
 RUN python3 -m pip install rust
+RUN python3 -m pip install pyyaml
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install rucio
 
@@ -39,8 +40,9 @@ COPY agents/justin-stage-cache.service    /usr/lib/systemd/system/
 
 COPY agents/justin.logrotate /etc/logrotate.d/justin.logrotate
 
-COPY  genericjobs/run-jobsub-submit  /var/lib/justin/
 COPY  genericjobs/justin-generic-job /var/lib/justin/
+COPY  genericjobs/execute-generic-job /var/lib/justin/
+COPY  genericjobs/justin-submit-wrapper /var/lib/justin/
 
 RUN mkdir /usr/lib/python3.6/site-packages/justin
 COPY modules/allocator.py /usr/lib/python3.6/site-packages/justin/

--- a/services/justin.conf
+++ b/services/justin.conf
@@ -1,5 +1,6 @@
 # goes in /etc/httpd/conf.d
 # Remove or rename ssl.conf in to get this to work?
+LoadModule wsgi_module "/usr/local/lib64/python3.6/site-packages/mod_wsgi/server/mod_wsgi-py36.cpython-36m-x86_64-linux-gnu.so"
 
 # This is in the context of the port 80 default HTTP virtual host
 RedirectMatch ^/$ https://justin.dune.hep.ac.uk/docs/


### PR DESCRIPTION
This PR has three commits.

- 94442e287b048d53dda54f93f786be509d68eb8e : Basically a set of "helpful" printouts, including one to show how to load mod_wsgi, using mod_wsgi-express
- 8f84fca58efe275012dc5e3636de5ca5cf0da87a : Fixes in the Dockerfile of justin, to make sure yaml can be imported and updates to the scripts that are needed for running
- 70e9fcaf3c7a0e6e2e92254d56bafdb22844061d : Here, the change is to actually load mod_wsgi at the beginning of the file. I am open to suggestions as to where that particular line should do.